### PR TITLE
Add new fme_repository_item type

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -41,9 +41,19 @@ class {'fme::api_settings':
 }
 
 fme_user {'myuser':
-  fullname  => 'My User',
-  password  => 'topsecret',
+  fullname => 'My User',
+  password => 'topsecret',
 }
+
+fme_repository {'my_repo':
+  ensure => present,
+}
+
+fme_repository_item {'my_repo/item.fmw':
+  ensure => present,
+  source => '/path/to/item.fmw',
+}
+
 ```
 
 ## Usage

--- a/lib/puppet/provider/fme_repository_item/rest_client.rb
+++ b/lib/puppet/provider/fme_repository_item/rest_client.rb
@@ -1,0 +1,111 @@
+require 'json'
+require 'rest-client' if Puppet.features.restclient?
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'puppet_x', 'fme', 'helper.rb'))
+
+Puppet::Type.type(:fme_repository_item).provide(:rest_client) do
+  confine :feature => :restclient
+
+  mk_resource_methods
+
+  def initialize(value={})
+    super(value)
+    @baseurl = Fme::Helper.get_url
+  end
+
+  def self.get_repos
+    url = "#{Fme::Helper.get_url}/repositories"
+    response = RestClient.get(url, {:params => {'detail' => 'high'}, :accept => :json})
+    repos = JSON.parse(response)
+    repos_array = []
+    repos.each do |repo|
+      repos_array.push(repo['name'])
+    end
+    repos_array
+  end
+
+  def self.get_items_from_repo(repo)
+    url = "#{Fme::Helper.get_url}/repositories/#{repo}/items"
+    response = RestClient.get(url, {:params => {'detail' => 'high'}, :accept => :json})
+    items = JSON.parse(response)
+    items.collect do |item|
+      item_properties = { ensure:         :present,
+                          provider:       :rest_client,
+                          item:           item['name'],
+                          description:    item['description'],
+                          item_title:     item['title'],
+                          type:           item['type'],
+                          last_save_date: item['lastSaveDate'],
+                          repository:     repo,
+                          name:           "#{repo}/#{item['name']}" }
+      item_properties
+    end
+  end
+
+  def self.instances
+    instances = []
+    get_repos.each do |repo|
+      get_items_from_repo(repo).each do |item|
+        instances.push(new(item))
+      end
+    end
+    instances
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name] # rubocop:disable Lint/AssignmentInCondition
+        resource.provider = prov
+      end
+    end
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    url = "#{@baseurl}/repositories/#{resource[:repository]}/items"
+    RestClient.post(url, read_item_from_file, get_post_params) do |response, request, result, &block|
+      case response.code
+      when 201
+        set_property_hash_from_create_response response
+      else
+        raise Puppet::Error, "FME Rest API returned #{response.code} when creating #{resource[:name]}. #{JSON.parse(response)}"
+      end
+    end
+  end
+
+  def get_post_params
+    params = { 'repository'         => resource[:repository],
+               'detail'             => 'low',
+               :multipart           => true,
+               :content_type        => 'application/octet-stream',
+               :content_disposition => "attachment; filename=\"#{File.basename(resource[:source])}\"",
+               :accept              => 'json' }
+    params
+  end
+
+  def read_item_from_file
+    data = File.new(resource[:source])
+    data
+  end
+
+  def set_property_hash_from_create_response(response)
+    response = JSON.parse(response)
+    @property_hash = { ensure:         :present,
+                       provider:       :rest_client,
+                       item:           response['name'],
+                       description:    response['description'],
+                       item_title:     response['title'],
+                       type:           response['type'],
+                       last_save_date: response['lastSaveDate'],
+                       repository:     resource[:repository],
+                       name:           "#{resource[:repository]}/#{response['name']}" }
+  end
+
+  def destroy
+    RestClient.delete("#{@baseurl}/repositories/#{resource[:repository]}/items/#{resource[:item]}", :accept => :json)
+    @property_hash[:ensure] = :absent
+  end
+end

--- a/lib/puppet/type/fme_repository_item.rb
+++ b/lib/puppet/type/fme_repository_item.rb
@@ -1,0 +1,92 @@
+Puppet::Type.newtype(:fme_repository_item) do
+  desc "Puppet type that manages FME repository item"
+
+  ensurable
+
+  autorequire(:file) do
+    Fme::Helper.settings_file
+  end
+
+  autorequire(:fme_repository) do
+    self[:repository]
+  end
+
+  def self.title_patterns
+    [
+      [
+        /^(.*)\/(.*)$/, # pattern to parse <repository>/<item>
+        [
+          [:repository, lambda{|x| x} ],
+          [:item,       lambda{|x| x} ]
+        ]
+      ],
+      [
+        /(.*)/, # Catch all workaround to avoid 'No set of title patterns matched the title'
+        [
+          [:dummy, lambda{|x| ""} ]
+        ]
+      ]
+    ]
+  end
+
+  validate do
+    fail "'name' should not be used" unless @original_parameters[:name].nil? or @original_parameters[:name] == "#{@original_parameters[:repository]}/#{@original_parameters[:item]}"
+    if match = @title.match(/^(.*)\/(.*)$/) # rubocop:disable Lint/AssignmentInCondition
+      fail "'repository' parameter #{self[:repository]} must match resource title #{@title} or be omitted" unless match.captures[0] == self[:repository]
+      fail "'item' parameter #{self[:item]} must match resource title #{@title} or be omitted" unless match.captures[1] == self[:item]
+    end
+    fail "source is required when ensure is present" if self[:ensure] == :present and self[:source].nil?
+  end
+
+  newparam(:dummy) do
+    validate { |value| fail "dummy parameter shouldn't be used" unless value.empty? }
+  end
+
+  newparam(:repository, :namevar => true) do
+    desc "Name of the repository containing the item"
+  end
+
+  newparam(:item, :namevar => true) do
+    desc "The name of the item"
+    newvalues(/[^\/]+\.(?:|fmw|fds|fmx|fmwt)/)
+  end
+
+  newparam(:name, :namevar => true) do
+    desc "The default namevar"
+    defaultto ""
+    munge do |value|
+      if value.empty? and resource[:repository] and resource[:item]
+       "#{resource[:repository]}/#{resource[:item]}"
+      else
+        fail "Use resource name style <repository>/<item> OR specify both 'repository' and 'item'" unless value.match /^(.*)\/(.*)$/
+      end
+    end
+  end
+
+  newparam(:source) do
+    desc "The file to upload.  Must be the absolute path to a file."
+    validate do |value|
+      fail "'source' file path must be fully qualified, not '#{value}'" unless Puppet::Util.absolute_path?(value)
+    end
+  end
+
+  newproperty(:description) do
+    desc "The item's description. Read-only"
+    validate { |val| fail "description is read-only" }
+  end
+
+  newproperty(:item_title) do
+    desc "The item's title. Read-only"
+    validate { |val| fail "item_title is read-only" }
+  end
+
+  newproperty(:type) do
+    desc "The item's type. Read-only"
+    validate { |val| fail "type is read-only" }
+  end
+
+  newproperty(:last_save_date) do
+    desc "The item's lastSaveDate. Read-only"
+    validate { |val| fail "last_save_date is read-only" }
+  end
+end

--- a/spec/unit/puppet/provider/fme_repository/rest_client_spec.rb
+++ b/spec/unit/puppet/provider/fme_repository/rest_client_spec.rb
@@ -4,7 +4,7 @@ provider_class = Puppet::Type.type(:fme_repository).provider(:rest_client)
 
 describe provider_class do
   before :each do
-    Fme::Helper.expects(:get_url).returns('www.example.com').at_most(99)
+    Fme::Helper.stubs(:get_url).returns('www.example.com')
   end
   describe 'instances' do
     it 'should have an instances method' do

--- a/spec/unit/puppet/provider/fme_repository_item/rest_client_spec.rb
+++ b/spec/unit/puppet/provider/fme_repository_item/rest_client_spec.rb
@@ -1,0 +1,213 @@
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:fme_repository_item).provider(:rest_client)
+
+describe provider_class do
+  before :each do
+    Fme::Helper.stubs(:get_url).returns('www.example.com')
+  end
+
+  describe 'instances' do
+    it 'should have an instances method' do
+      expect(described_class).to respond_to :instances
+    end
+
+    describe 'returns correct instances' do
+      context 'when there are no repositories' do
+        before :each do
+          stub_request(:get, "http://www.example.com/repositories?detail=high").to_return(:body => [].to_json)
+        end
+        it 'should return no resources' do
+          expect(described_class.instances.size).to eq(0)
+        end
+      end
+      context 'when there is 1 repository with no items' do
+        before :each do
+          stub_request(:get, "http://www.example.com/repositories?detail=high").
+            to_return(:body => [{'name'=>'repo1', 'description'=>'empty repo'}].to_json)
+          stub_request(:get, "http://www.example.com/repositories/repo1/items?detail=high").to_return(:body => [].to_json)
+        end
+        it 'should return no resources' do
+          expect(described_class.instances.size).to eq(0)
+        end
+      end
+      context 'when there are 2 repositories with 2 items' do
+        before :each do
+          stub_request(:get, "http://www.example.com/repositories?detail=high").
+            to_return(:body =>
+                      [
+                        {'name'=>'repo1', 'description'=>'test repo1'},
+                        {'name'=>'repo2', 'description'=>'test repo2'}
+                      ].to_json)
+            stub_request(:get, "http://www.example.com/repositories/repo1/items?detail=high").
+              to_return(:body =>
+                        [
+                          {'name'=>'item1.fmw', 'description' => 'item1 description', 'title' => 'title1', 'type' => 'WORKSPACE', 'lastSaveDate' => '2014-12-11T11:36:12'},
+                          {'name'=>'item2.fmw', 'description' => 'item2 description', 'title' => 'title2', 'type' => 'WORKSPACE', 'lastSaveDate' => '2014-12-11T11:36:13'}
+                        ].to_json)
+              stub_request(:get, "http://www.example.com/repositories/repo2/items?detail=high").
+                to_return(:body =>
+                          [
+                            {'name'=>'item3.fmw', 'description' => 'item3 description', 'title' => 'title3', 'type' => 'WORKSPACE', 'lastSaveDate' => '2014-12-11T11:36:14'},
+                            {'name'=>'item4.fmw', 'description' => 'item4 description', 'title' => 'title4', 'type' => 'WORKSPACE', 'lastSaveDate' => '2014-12-11T11:36:15'}
+                          ].to_json)
+        end
+
+        it 'should return 4 resources' do
+          expect(described_class.instances.size).to eq(4)
+        end
+
+        it 'should return the resource repo1/item1.fmw' do
+          expect(described_class.instances[0].instance_variable_get("@property_hash")).to eq( {
+            :ensure         => :present,
+            :provider       => :rest_client,
+            :name           => 'repo1/item1.fmw',
+            :description    => 'item1 description',
+            :repository     => 'repo1',
+            :item           => 'item1.fmw',
+            :type           => 'WORKSPACE',
+            :last_save_date => '2014-12-11T11:36:12',
+            :item_title     => 'title1'
+          } )
+        end
+
+        it 'should return the resource repo1/item2.fmw' do
+          expect(described_class.instances[1].instance_variable_get("@property_hash")).to eq( {
+            :ensure         => :present,
+            :provider       => :rest_client,
+            :name           => 'repo1/item2.fmw',
+            :description    => 'item2 description',
+            :repository     => 'repo1',
+            :item           => 'item2.fmw',
+            :type           => 'WORKSPACE',
+            :last_save_date => '2014-12-11T11:36:13',
+            :item_title     => 'title2'
+          } )
+        end
+
+        it 'should return the resource repo2/item3.fmw' do
+          expect(described_class.instances[2].instance_variable_get("@property_hash")).to eq( {
+            :ensure         => :present,
+            :provider       => :rest_client,
+            :name           => 'repo2/item3.fmw',
+            :description    => 'item3 description',
+            :repository     => 'repo2',
+            :item           => 'item3.fmw',
+            :type           => 'WORKSPACE',
+            :last_save_date => '2014-12-11T11:36:14',
+            :item_title     => 'title3'
+          } )
+        end
+
+        it 'should return the resource repo2/item4.fmw' do
+          expect(described_class.instances[3].instance_variable_get("@property_hash")).to eq( {
+            :ensure         => :present,
+            :provider       => :rest_client,
+            :name           => 'repo2/item4.fmw',
+            :description    => 'item4 description',
+            :repository     => 'repo2',
+            :item           => 'item4.fmw',
+            :type           => 'WORKSPACE',
+            :last_save_date => '2014-12-11T11:36:15',
+            :item_title     => 'title4'
+          } )
+        end
+      end
+    end
+  end
+
+  describe 'prefetch' do
+    it 'should have a prefetch method' do
+      expect(described_class).to respond_to :prefetch
+    end
+  end
+
+  context 'when an instance' do
+    let(:title) { 'repo/item.fmw' }
+    let(:resource) do
+      Puppet::Type.type(:fme_repository_item).new(
+        :title    => title,
+        :source   => '/path/to/item.fmw',
+        :ensure   => :present,
+        :provider => :rest_client
+      )
+    end
+
+    let(:provider) do
+      provider = provider_class.new
+      provider.resource = resource
+      provider
+    end
+
+    describe 'is being checked for existence' do
+      it 'should indicate when the fme_repository_item already exists' do
+        provider = provider_class.new(:ensure => :present)
+        expect(provider.exists?).to be_truthy
+      end
+      it 'should indicate when the fme_repository_item does not exist' do
+        provider = provider_class.new(:ensure => :absent)
+        expect(provider.exists?).to be_falsey
+      end
+    end
+
+    describe 'is being created' do
+      before :each do
+        provider.stubs(:read_item_from_file).returns('FILEDATA')
+      end
+      it 'should have a create method' do
+        expect(provider).to respond_to(:create)
+      end
+      context 'when API returns success' do
+        before :each do
+          stub_request(:post, "http://www.example.com/repositories/repo/items").
+            with(:body => "FILEDATA",
+                 :headers => {'Accept'=>'application/json', 'Content-Disposition'=>'attachment; filename="item.fmw"', 'Content-Type'=>'application/octet-stream', 'Detail'=>'low', 'Multipart'=>'true', 'Repository'=>'repo'}).
+            to_return(:status => 201, :body => {'name'=>'test.fmw', 'description' => 'a description', 'title' => 'a title', 'type' => 'WORKSPACE', 'lastSaveDate' => '2014-12-11T11:32:50'}.to_json)
+        end
+        it 'should create a repository_item' do
+          provider.create
+          expect(provider.instance_variable_get("@property_hash")).to eq( {
+            :ensure         => :present,
+            :provider       => :rest_client,
+            :name           => 'repo/test.fmw',
+            :repository     => 'repo',
+            :item           => 'test.fmw',
+            :item_title     => 'a title',
+            :type           => 'WORKSPACE',
+            :last_save_date => '2014-12-11T11:32:50',
+            :description    => 'a description'
+          } )
+        end
+      end
+      context 'when API returns an error' do
+        before :each do
+          stub_request(:post, "http://www.example.com/repositories/repo/items").
+            with(:body => "FILEDATA",
+                 :headers => {'Accept'=>'application/json', 'Content-Disposition'=>'attachment; filename="item.fmw"', 'Content-Type'=>'application/octet-stream', 'Detail'=>'low', 'Multipart'=>'true', 'Repository'=>'repo'}).
+            to_return(:status => 409, :body => {'what'=>'test.fmw', 'reason' => 'exists', 'message' => "File 'test.fmw' already exists"}.to_json)
+        end
+        it 'should raise an exception' do
+          expect{ provider.create }.to raise_error(Puppet::Error, /FME Rest API returned 409 when creating repo\/item\.fmw/)
+        end
+      end
+    end
+    describe 'is being destroyed' do
+      before :each do
+        stub_request(:delete, "http://www.example.com/repositories/repo/items/item.fmw").
+          to_return(:status => 200)
+      end
+      it 'should have @property_hash :ensure set to :absent' do
+        provider.destroy
+        expect(provider.instance_variable_get("@property_hash")).to eq( { :ensure => :absent } )
+      end
+    end
+    describe 'read_item_from_file' do
+      before :each do
+        File.expects(:new).with('/path/to/item.fmw').returns('DATA')
+      end
+      it 'should return data from a file' do
+        expect(provider.read_item_from_file).to eq('DATA')
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/provider/fme_user/rest_client_spec.rb
+++ b/spec/unit/puppet/provider/fme_user/rest_client_spec.rb
@@ -2,6 +2,9 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:fme_user).provider(:rest_client)
 describe provider_class do
+  before :each do
+    Fme::Helper.stubs(:get_url).returns('www.example.com')
+  end
   let :resource do
     Puppet::Type.type(:fme_user).new(:name => "testuser", :provider => :rest_client)
   end
@@ -16,7 +19,6 @@ describe provider_class do
     end
     describe 'without users' do
       before :each do
-        Fme::Helper.expects(:get_url).returns('www.example.com')
         stub_request(:get, 'http://www.example.com/security/accounts?detail=high').
           to_return(:body => '[]')
       end
@@ -26,7 +28,6 @@ describe provider_class do
     end
     describe 'with 1 user' do
       before :each do
-        Fme::Helper.expects(:get_url).returns('www.example.com')
         stub_request(:get, 'http://www.example.com/security/accounts?detail=high').
           to_return(:body =>
                     '[{"fullName": "test user",
@@ -49,7 +50,6 @@ describe provider_class do
     end
     describe 'with 2 users' do
       before :each do
-        Fme::Helper.expects(:get_url).returns('www.example.com')
         stub_request(:get, 'http://www.example.com/security/accounts?detail=high').
           to_return(:body =>
                     '[{"fullName": "test user",
@@ -111,9 +111,6 @@ describe provider_class do
   end
 
   describe 'modify_user' do
-    before :each do
-      Fme::Helper.expects(:get_url).returns('www.example.com')
-    end
     context 'when API returns response code 200' do
       before :each do
         stub_request(:put, "http://www.example.com/security/accounts/testuser?detail=high&name=testuser").to_return(:status => 200, :body => '{"fullName": "test user","name": "testuser","roles": ["fmeuser"]}')
@@ -154,7 +151,6 @@ describe provider_class do
       end
       context 'when password is set' do
         before :each do
-          Fme::Helper.expects(:get_url).returns('www.example.com')
           stub_request(:post, "http://www.example.com/security/accounts?name=testuser")
         end
         it 'should create user' do
@@ -180,7 +176,6 @@ describe provider_class do
     describe 'is being flushed' do
       context 'when being deleted' do
         before :each do
-          Fme::Helper.expects(:get_url).returns('www.example.com')
           stub_request(:delete, "http://www.example.com/security/accounts/testuser")
           provider.instance_variable_set(:@property_flush, { :ensure => :absent } )
         end

--- a/spec/unit/puppet/type/fme_repository_item_spec.rb
+++ b/spec/unit/puppet/type/fme_repository_item_spec.rb
@@ -1,0 +1,101 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:fme_repository_item) do
+  before :each do
+    Fme::Helper.stubs(:get_url).returns('www.example.com')
+  end
+  describe 'when validating attributes' do
+    [ :name, :provider, :repository, :item, :source ].each do |param|
+      it "should have a #{param} parameter" do
+        expect(described_class.attrtype(param)).to eq(:param)
+      end
+    end
+    [ :ensure, :description, :item_title, :type, :last_save_date ].each do |prop|
+      it "should have a #{prop} property" do
+        expect(described_class.attrtype(prop)).to eq(:property)
+      end
+    end
+  end
+
+  describe 'namevars' do
+    it "should have 3 namevars" do
+      expect(described_class.key_attributes.size).to eq(3)
+    end
+    [ :name, :repository, :item ].each do |param|
+      it "'#{param}' should be a namevar" do
+        expect(described_class.key_attributes).to include(param)
+      end
+    end
+  end
+
+  describe 'when validating attribute values' do
+    describe 'ensure' do
+      [ :present, :absent ].each do |value|
+        it "should support #{value} as a value to ensure" do
+          expect { described_class.new( {:title => 'repo/item.fmw', :source => '/path/to/item.fmw', :ensure => value})}.to_not raise_error
+        end
+      end
+      it 'should not support other values' do
+        expect { described_class.new( {:title => 'repo/item.fmw',:ensure => 'foo'})}.to raise_error(Puppet::Error, /Invalid value/)
+      end
+    end
+
+    describe 'name' do
+      context "when not set" do
+        it 'should be munged to <repository>/<item>' do
+          expect { @item = described_class.new( {:title => 'resourcetitle', :repository => 'repo', :item => 'item.fmw', :source => '/path/to/item.fmw', :ensure => :present})}.to_not raise_error
+          expect(@item[:name]).to eq('repo/item.fmw')
+        end
+      end
+      context "when set" do
+        context "to match <repository>/<item>" do
+          it 'should raise error' do
+            expect { @item = described_class.new( {:title => 'resourcetitle', :name => 'repo/item.fmw', :repository => 'repo', :item => 'item.fmw', :source => '/path/to/item.fmw', :ensure => :present})}.to_not raise_error
+          end
+        end
+        context "with mismatched repository or item" do
+          it 'should raise error' do
+            expect { @item = described_class.new( {:title => 'resourcetitle', :name => 'repo2/item42.fmw', :repository => 'repo', :item => 'item.fmw', :source => '/path/to/item.fmw', :ensure => :present})}.to raise_error(Puppet::Error, /'name' should not be used/)
+          end
+        end
+      end
+    end
+
+    describe 'read-only properties' do
+      before :each do
+        @item = Puppet::Type.type(:fme_repository_item).new( {:title => 'repo/item.fmw', :ensure => 'present', :source => '/path/to/item.fmw'} )
+      end
+      [ :description, :item_title, :type, :last_save_date ].each do |param|
+        describe param do
+          it 'should raise error' do
+            expect { @item[param] = 'foo' }.to raise_error(Puppet::Error, /#{param} is read-only/)
+          end
+        end
+      end
+    end
+  end
+
+  describe 'autorequiring' do
+    before :each do
+      @settings_file = Puppet::Type.type(:file).new(:name => '/etc/fme_api_settings.yaml', :ensure => :file)
+      @repository    = Puppet::Type.type(:fme_repository).new(:name => 'repo', :ensure => :present)
+      @catalog = Puppet::Resource::Catalog.new
+      @catalog.add_resource @settings_file
+      @catalog.add_resource @repository
+    end
+
+    it 'should autorequire the settings file' do
+      @resource = described_class.new(:title => 'resourcetitle', :repository => 'repo', :item => 'item.fmw', :source => '/path/to/item.fmw', :ensure => :present)
+      @catalog.add_resource @resource
+      req = @resource.autorequire
+      expect(req.find {|relationship| relationship.source == @settings_file and relationship.target == @resource}).to_not be_nil
+    end
+
+    it 'should autorequire its repository' do
+      @resource = described_class.new(:title => 'resourcetitle', :repository => 'repo', :item => 'item.fmw', :source => '/path/to/item.fmw', :ensure => :present)
+      @catalog.add_resource @resource
+      req = @resource.autorequire
+      expect(req.find {|relationship| relationship.source == @repository and relationship.target == @resource}).to_not be_nil
+    end
+  end
+end

--- a/spec/unit/puppet/type/fme_repository_spec.rb
+++ b/spec/unit/puppet/type/fme_repository_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Puppet::Type.type(:fme_repository) do
   before :each do
-    Fme::Helper.expects(:get_url).returns('www.example.com').at_most(99)
+    Fme::Helper.stubs(:get_url).returns('www.example.com')
   end
   describe 'when validating attributes' do
     [ :name, :provider ].each do |param|


### PR DESCRIPTION
The new type uploads workspaces to FME repositories.  If the FME
repository is also being managed by puppet, `fme_repository_item`s will
autorequire them.
