### PR TITLE
Fix issue with munging :name

### DIFF
--- a/lib/puppet/type/fme_repository_item.rb
+++ b/lib/puppet/type/fme_repository_item.rb
@@ -59,6 +59,7 @@ Puppet::Type.newtype(:fme_repository_item) do
        "#{resource[:repository]}/#{resource[:item]}"
       else
         fail "Use resource name style <repository>/<item> OR specify both 'repository' and 'item'" unless value.match /^(.*)\/(.*)$/
+        value
       end
     end
   end

--- a/spec/unit/puppet/type/fme_repository_item_spec.rb
+++ b/spec/unit/puppet/type/fme_repository_item_spec.rb
@@ -49,8 +49,9 @@ describe Puppet::Type.type(:fme_repository_item) do
       end
       context "when set" do
         context "to match <repository>/<item>" do
-          it 'should raise error' do
+          it 'should be unaffected by munge' do
             expect { @item = described_class.new( {:title => 'resourcetitle', :name => 'repo/item.fmw', :repository => 'repo', :item => 'item.fmw', :source => '/path/to/item.fmw', :ensure => :present})}.to_not raise_error
+            expect(@item[:name]).to eq('repo/item.fmw')
           end
         end
         context "with mismatched repository or item" do


### PR DESCRIPTION
puppet resource fme_repository_item <repo>/<item> was failing to return
the resource as :name was being accidentally munged to nil.
