### PR TITLE
Use ruby1.8 compatible hashes

### DIFF
--- a/lib/puppet/provider/fme_repository_item/rest_client.rb
+++ b/lib/puppet/provider/fme_repository_item/rest_client.rb
@@ -30,15 +30,15 @@ Puppet::Type.type(:fme_repository_item).provide(:rest_client, :parent => Puppet:
     response = RestClient.get(url, {:params => {'detail' => 'high'}, :accept => :json})
     items = JSON.parse(response)
     items.collect do |item|
-      item_properties = { ensure:         :present,
-                          provider:       :rest_client,
-                          item:           item['name'],
-                          description:    item['description'],
-                          item_title:     item['title'],
-                          type:           item['type'],
-                          last_save_date: item['lastSaveDate'],
-                          repository:     repo,
-                          name:           "#{repo}/#{item['name']}" }
+      item_properties = { :ensure         => :present,
+                          :provider       => :rest_client,
+                          :item           => item['name'],
+                          :description    => item['description'],
+                          :item_title     => item['title'],
+                          :type           => item['type'],
+                          :last_save_date => item['lastSaveDate'],
+                          :repository     => repo,
+                          :name           => "#{repo}/#{item['name']}" }
       item_properties
     end
   end
@@ -91,15 +91,15 @@ Puppet::Type.type(:fme_repository_item).provide(:rest_client, :parent => Puppet:
 
   def set_property_hash_from_create_response(response)
     response = JSON.parse(response)
-    @property_hash = { ensure:         :present,
-                       provider:       :rest_client,
-                       item:           response['name'],
-                       description:    response['description'],
-                       item_title:     response['title'],
-                       type:           response['type'],
-                       last_save_date: response['lastSaveDate'],
-                       repository:     resource[:repository],
-                       name:           "#{resource[:repository]}/#{response['name']}" }
+    @property_hash = { :ensure         => :present,
+                       :provider       => :rest_client,
+                       :item           => response['name'],
+                       :description    => response['description'],
+                       :item_title     => response['title'],
+                       :type           => response['type'],
+                       :last_save_date => response['lastSaveDate'],
+                       :repository     => resource[:repository],
+                       :name           => "#{resource[:repository]}/#{response['name']}" }
   end
 
   def destroy

--- a/lib/puppet/provider/fme_resource/rest_client.rb
+++ b/lib/puppet/provider/fme_resource/rest_client.rb
@@ -42,8 +42,8 @@ Puppet::Type.type(:fme_resource).provide(:rest_client) do
   end
 
   def extract_metadata_from_response(json)
-    metadata = { ensure: :file      } if json['type'] == 'FILE'
-    metadata = { ensure: :directory } if json['type'] == 'DIR'
+    metadata = { :ensure => :file      } if json['type'] == 'FILE'
+    metadata = { :ensure => :directory } if json['type'] == 'DIR'
     metadata[:path] = "#{json['path']}#{json['name']}"
     metadata[:size] = json['size'] unless json['size'] == 0
     metadata


### PR DESCRIPTION
The module still requires ruby 1.9 on the puppet agent, but hopefully
this should relax that requirement on the puppet master.
