### PR TITLE
Add fme_service type

### DIFF
--- a/lib/puppet/provider/fme_service/rest_client.rb
+++ b/lib/puppet/provider/fme_service/rest_client.rb
@@ -1,0 +1,75 @@
+require 'json'
+require 'rest-client' if Puppet.features.restclient?
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'puppet_x', 'fme', 'helper.rb'))
+require File.join(File.dirname(__FILE__), '..', 'fme')
+
+class String
+  def underscore
+    gsub(%r{::}, '/').
+      gsub(%r{([A-Z]+)([A-Z][a-z])}, '\1_\2').
+      gsub(%r{([a-z\d])([A-Z])}, '\1_\2').
+      tr('-', '_').
+      downcase
+  end
+end
+
+Puppet::Type.type(:fme_service).provide(:rest_client, :parent => Puppet::Provider::Fme) do
+  confine :feature => :restclient
+  if Puppet::Util::Platform.windows?
+    confine :exists => 'C:/fme_api_settings.yaml'
+  else
+    confine :exists => '/etc/fme_api_settings.yaml'
+  end
+
+  mk_resource_methods
+
+  def self.instances
+    retrieve_all_services.map do |service|
+      service_properties = {}
+      service_properties[:ensure]       = :present
+      service_properties[:provider]     = :rest_client
+      service_properties[:name]         = service['name']
+      service_properties[:url]          = service['url']
+      service_properties[:description]  = service['description']
+      service_properties[:display_name] = service['displayName']
+      service_properties[:enabled]      = service['enabled']
+      new(service_properties)
+    end
+  end
+
+  def self.retrieve_all_services(detail = 'low')
+    url = "#{Fme::Helper.get_url}/services"
+    response = RestClient.get(url, :params => { 'detail' => detail }, :accept => :json)
+    JSON.parse(response)
+  end
+
+  def url=(should)
+    update_property('URL', should)
+  end
+
+  def description=(should)
+    update_property('description', should)
+  end
+
+  def display_name=(should)
+    update_property('displayName', should)
+  end
+
+  def enabled=(should)
+    update_property('enabled', should)
+  end
+
+  def update_property(property, value)
+    url = "#{Fme::Helper.get_url}/services/#{resource[:name]}/#{property}"
+    form_data = URI.encode_www_form('value' => value)
+    RestClient.put("#{url}?detail=low", form_data, :content_type => 'application/x-www-form-urlencoded', :accept => :json) do |response, _request, _result|
+      case response.code
+      when 200
+        @property_hash[property.underscore.to_sym] = value
+      else
+        raise Puppet::Error, "FME Rest API returned #{response.code} when modifying #{resource[:name]} #{property}. #{JSON.parse(response)}"
+      end
+    end
+  end
+end

--- a/lib/puppet/type/fme_service.rb
+++ b/lib/puppet/type/fme_service.rb
@@ -1,0 +1,38 @@
+Puppet::Type.newtype(:fme_service) do
+  desc 'Puppet type that manages FME services'
+
+  ensurable do
+    newvalue(:present) do
+      raise Puppet::Error, 'Creation of fme_service resources not implemented'
+    end
+
+    newvalue(:absent) do
+      raise Puppet::Error, 'Deletion of fme_service resources not implemented'
+    end
+
+    defaultto(:present)
+  end
+
+  autorequire(:file) do
+    Fme::Helper.settings_file
+  end
+
+  newparam(:name, :namevar => true) do
+    desc 'Unique name of the service'
+  end
+
+  newproperty(:display_name) do
+    desc 'Friendly name of the service'
+  end
+
+  newproperty(:description) do
+    desc 'Human readable description of the service'
+  end
+
+  newproperty(:enabled) do
+  end
+
+  newproperty(:url) do
+    desc 'The URL pattern of the service'
+  end
+end

--- a/spec/unit/puppet/provider/fme_service/rest_client_spec.rb
+++ b/spec/unit/puppet/provider/fme_service/rest_client_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:fme_service).provider(:rest_client)
+
+RSpec.describe provider_class do
+  before :each do
+    Fme::Helper.stubs(:get_url).returns('www.example.com')
+  end
+  let(:name)     { 'my_service' }
+  let(:resource) { Puppet::Type::Fme_service.new(resource_properties) }
+  let(:provider) { provider_class.new(resource) }
+  let(:resource_properties) do
+    {
+      name: name
+    }
+  end
+
+  describe 'property setters' do
+    describe '#url=' do
+      it 'calls update_property with \'URL\' and value' do
+        provider.expects(:update_property).with('URL', 'value')
+        provider.url = 'value'
+      end
+    end
+
+    describe '#description=' do
+      it 'calls update_property with \'description\' and value' do
+        provider.expects(:update_property).with('description', 'value')
+        provider.description = 'value'
+      end
+    end
+
+    describe '#display_name=' do
+      it 'calls update_property with \'displayName\' and value' do
+        provider.expects(:update_property).with('displayName', 'value')
+        provider.display_name = 'value'
+      end
+    end
+
+    describe '#enabled=' do
+      it 'calls update_property with \'enabled\' and value' do
+        provider.expects(:update_property).with('enabled', 'value')
+        provider.enabled = 'value'
+      end
+    end
+  end
+  describe '#update_property' do
+    context 'when updating displayName' do
+      context 'when API returns success' do
+        before :each do
+          stub_request(:put, 'http://www.example.com/services/my_service/displayName?detail=low').
+            with(:body => { 'value' => 'value' },
+                 :headers => { 'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded' }).
+            to_return(:status => 200, :body => '')
+        end
+        it 'sets :display_name in @property_hash' do
+          provider.update_property('displayName', 'value')
+          expect(provider.instance_variable_get('@property_hash')).to eq(:display_name => 'value')
+        end
+      end
+      context 'when API returns failure' do
+        before :each do
+          stub_request(:put, 'http://www.example.com/services/my_service/displayName?detail=low').
+            with(:body => { 'value' => 'value' },
+                 :headers => { 'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded' }).
+            to_return(:status => 421, :body => '{"message": "An error message"}')
+        end
+        it 'raises an error' do
+          expect { provider.update_property('displayName', 'value') }.
+            to raise_error(Puppet::Error,
+                           %r[FME Rest API returned 421 when modifying my_service displayName\. {"message"=>"An error message"}])
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/type/fme_service_spec.rb
+++ b/spec/unit/puppet/type/fme_service_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:fme_service) do
+  describe 'when validating attributes' do
+    [:name, :provider].each do |param|
+      it "should have a #{param} parameter" do
+        expect(described_class.attrtype(param)).to eq(:param)
+      end
+    end
+    [:ensure, :display_name, :url, :description].each do |prop|
+      it "should have a #{prop} property" do
+        expect(described_class.attrtype(prop)).to eq(:property)
+      end
+    end
+  end
+  describe 'namevar validation' do
+    it 'should have :name as its namevar' do
+      expect(described_class.key_attributes).to eq([:name])
+    end
+  end
+  describe 'when validating attribute values' do
+    describe 'ensure' do
+      before :each do
+        @provider_class = Puppet::Type.type(:fme_service).provider(:rest_client)
+        @provider = stub('provider', :class => @provider_class, :clear => nil)
+        @provider_class.stubs(:new).returns(@provider)
+
+        Puppet::Type.type(:fme_service).stubs(:defaultprovider).returns @provider_class
+
+        @resource = Puppet::Type.type(:fme_service).new(:title => 'service', :ensure => :present)
+        @property = @resource.property(:ensure)
+      end
+      [:present, :absent].each do |value|
+        it "should support #{value} as a value to ensure" do
+          expect { described_class.new(:name => 'example_service', :ensure => value) }.to_not raise_error
+        end
+      end
+      it 'should not support other values' do
+        expect { described_class.new(:name => 'example_service', :ensure => 'foo') }.to raise_error(Puppet::Error, %r{Invalid value})
+      end
+      describe 'Creating and deleting services' do
+        it 'does not support deleting fme_services' do
+          @property.should = :absent
+          expect { @property.sync }.to raise_error(Puppet::Error, %r{Deletion of fme_service resources not implemented})
+        end
+        it 'does not support creating fme_services' do
+          @property.should = :present
+          expect { @property.sync }.to raise_error(Puppet::Error, %r{Creation of fme_service resources not implemented})
+        end
+      end
+    end
+  end
+
+  describe 'autorequiring' do
+    before :each do
+      @settings_file = Puppet::Type.type(:file).new(:name => '/etc/fme_api_settings.yaml', :ensure => :file)
+      @catalog = Puppet::Resource::Catalog.new
+      @catalog.add_resource @settings_file
+    end
+
+    it 'should autorequire the settings file' do
+      @resource = described_class.new(:ensure => :present, :name => 'example_service', :description => 'new description')
+      @catalog.add_resource @resource
+      req = @resource.autorequire
+      expect(req.size).to eq(1)
+      expect(req[0].target).to eq(@resource)
+      expect(req[0].source).to eq(@settings_file)
+    end
+  end
+end


### PR DESCRIPTION
Type is limited to updating properties `display_name`, `description`,
`url` and `enabled`.  It is not possible to update the service's
`property array` and because of this, creation and deletion of
`fme_service` resources is not implemented either.
