### PR TITLE
Fix error caused by path value on windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,23 +3,11 @@ language: ruby
 bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.0
 script:
   - 'bundle exec rake $CHECK'
-env:
-  - PUPPET_GEM_VERSION="~> 3.4.0" CHECK=test
-  - PUPPET_GEM_VERSION="~> 3.5.0" STRICT_VARIABLES=yes CHECK=test
-  - PUPPET_GEM_VERSION="~> 3.6.0" STRICT_VARIABLES=yes CHECK=test
-  - PUPPET_GEM_VERSION="~> 3.7.0" STRICT_VARIABLES=yes CHECK=test
-  - PUPPET_GEM_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes CHECK=test
-  - PUPPET_GEM_VERSION="~> 3.8.0" STRICT_VARIABLES=yes CHECK=test
-  - PUPPET_GEM_VERSION="~> 3.8.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes CHECK=test
 matrix:
-  exclude:
-  - rvm: 2.1.0
-    env: PUPPET_GEM_VERSION="~> 3.4.0" CHECK=test
   include:
   - rvm: 2.1.7
     env: PUPPET_GEM_VERSION="~> 4.0" CHECK=test

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 group :test do
   gem 'rake'
-  gem 'puppet', ENV['PUPPET_GEM_VERSION'] || '~> 3.8.0'
-  gem 'rspec', '< 3.2.0'
+  gem 'puppet', ENV['PUPPET_GEM_VERSION'] || '~> 4.0'
+  gem 'rspec'
   gem 'rspec-puppet'
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
@@ -24,17 +24,9 @@ group :test do
   gem 'mocha'
   gem 'fakefs'
 
-  if RUBY_VERSION < '2.0'
-    gem 'json',           '~> 1.8'
-    gem 'json_pure',      '= 2.0.1'
-    gem 'addressable',    '= 2.3.8'
-    gem 'tins',           '= 1.6.0'
-    gem 'term-ansicolor', '< 1.4.0'
-  else
-    gem 'json'
-    gem 'tins'
-    gem 'rubocop', '0.44.1'
-  end
+  gem 'json'
+  gem 'tins'
+  gem 'rubocop', '0.44.1'
 end
 
 group :development do

--- a/lib/puppet/type/fme_resource.rb
+++ b/lib/puppet/type/fme_resource.rb
@@ -122,7 +122,7 @@ Puppet::Type.newtype(:fme_resource) do
 
   newparam(:path, :namevar => true) do
     validate do |value|
-      raise Puppet::Error, "'path' file path must be absolute, not '#{value}'" unless Puppet::Util.absolute_path?(value)
+      raise Puppet::Error, "'path' file path must start with /, not '#{value}'" unless value.start_with?('/')
     end
   end
 


### PR DESCRIPTION
Fails validation when path starts with '/' as expected rather than drive letter on windows